### PR TITLE
5 add way to create everything for full template repo

### DIFF
--- a/.github/workflows/generate-full-template.yml
+++ b/.github/workflows/generate-full-template.yml
@@ -1,0 +1,30 @@
+name: Create, push and delete folder
+
+on:
+  workflow_dispatch
+
+
+jobs:
+  push_to_another_repo:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Source Repo
+        uses: actions/checkout@v2
+
+      - name: Run your code
+        run: |
+          python generate_full/generate.py
+
+      - name: Push to Target Repo
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.GIT_TARGET_TOKEN }}
+        with:
+          source-directory: 'generate_full/target'
+          destination-github-username: 'AutoResearch'
+          destination-repository-name: 'autora-contributor-template'
+          target-branch: main
+
+      - name: Remove the generated folder
+        run: rm -rf ./generate_full/target

--- a/generate_full/generate.py
+++ b/generate_full/generate.py
@@ -2,8 +2,6 @@ import os
 from cookiecutter.main import cookiecutter
 import shutil
 
-
-
 DIR = os.path.dirname(os.path.realpath(__file__))
 PARENT = os.path.join(DIR, '..')
 FOLDER_NAME = "target"
@@ -21,7 +19,7 @@ def bake_contribution(contrib_type, sub_type=None):
     if sub_type is not None:
         name = f"{contrib_type}-{sub_type}-example"
     else:
-        name =  f"{contrib_type}-example"
+        name = f"{contrib_type}-example"
     extra_content = {
         "__contrib_name": name,
         "__autora_contribution_type": contrib_type,
@@ -33,6 +31,7 @@ def bake_contribution(contrib_type, sub_type=None):
         no_input=True,
         extra_context=extra_content,
         output_dir=FOLDER_PATH)
+
 
 def copy_new_files(src, dst):
     """Copy files from src to dst, only if they don't exist in dst."""
@@ -46,6 +45,28 @@ def copy_new_files(src, dst):
     else:
         if not os.path.exists(dst):
             shutil.copy2(src, dst)
+
+
+def create_readme():
+    readme_src = os.path.join(PARENT, '{{ cookiecutter.__project_slug }}/README.md')
+    readme_dist = os.path.join(FOLDER_PATH, 'README.md')
+
+    shutil.copy(readme_src, readme_dist)
+
+    # rempove lines starting with {%
+    output_lines = []
+    with open(readme_dist, "r") as file:
+        for line in file:
+            # Skip lines that start with "{%"
+            if line.lstrip().startswith("{%"):
+                continue
+            output_lines.append(line)
+
+    # Write the output lines back to the README
+    with open(readme_dist, "w") as file:
+        for line in output_lines:
+            file.write(line)
+
 
 def main():
     # create all contributions
@@ -62,14 +83,14 @@ def main():
     # get a list of all created folders
     contribution_folders = [name for name in os.listdir(FOLDER_PATH) if os.path.isdir(os.path.join(FOLDER_PATH, name))]
 
-
-    # make autora
-    os.makedirs(os.path.join(FOLDER_PATH, '.'), exist_ok=True)
-
     # copy all folders into the autora folder (if they don't exist)
     for f in contribution_folders:
-        copy_new_files(os.path.join(FOLDER_PATH, f), os.path.join(FOLDER_PATH, '.'))
-        shutil.rmtree(os.path.join(FOLDER_PATH, f))
+        src_folder = os.path.join(FOLDER_PATH, f)
+        copy_new_files(src_folder, os.path.join(FOLDER_PATH, '.'))
+        shutil.rmtree(src_folder)
+
+    create_readme()
+
 
 if __name__ == '__main__':
     main()

--- a/generate_full/generate.py
+++ b/generate_full/generate.py
@@ -1,0 +1,12 @@
+import os
+
+DIR = os.path.dirname(os.path.realpath(__file__))
+FOLDER_NAME = "target"
+FOLDER_PATH = os.path.join(DIR, FOLDER_NAME)
+
+# Create the directory
+os.makedirs(FOLDER_PATH, exist_ok=True)
+
+# Create a test file within the directory
+with open(os.path.join(FOLDER_PATH, "testfile.txt"), "w") as file:
+    file.write("This is a test file")

--- a/generate_full/generate.py
+++ b/generate_full/generate.py
@@ -1,12 +1,75 @@
 import os
+from cookiecutter.main import cookiecutter
+import shutil
+
+
 
 DIR = os.path.dirname(os.path.realpath(__file__))
+PARENT = os.path.join(DIR, '..')
 FOLDER_NAME = "target"
 FOLDER_PATH = os.path.join(DIR, FOLDER_NAME)
 
 # Create the directory
 os.makedirs(FOLDER_PATH, exist_ok=True)
 
-# Create a test file within the directory
-with open(os.path.join(FOLDER_PATH, "testfile.txt"), "w") as file:
-    file.write("This is a test file")
+contribution_types = ["theorist", "experimentalist", "experiment_runner", "synthetic_data"]
+experimentalist_subtype = ["sampler", "pooler"]
+runner_subtypes = ["experimentation_manager", "recruitment_manager"]
+
+
+def bake_contribution(contrib_type, sub_type=None):
+    if sub_type is not None:
+        name = f"{contrib_type}-{sub_type}-example"
+    else:
+        name =  f"{contrib_type}-example"
+    extra_content = {
+        "__contrib_name": name,
+        "__autora_contribution_type": contrib_type,
+    }
+    if sub_type is not None:
+        extra_content['__contrib_subtype'] = sub_type
+    cookiecutter(
+        PARENT,
+        no_input=True,
+        extra_context=extra_content,
+        output_dir=FOLDER_PATH)
+
+def copy_new_files(src, dst):
+    """Copy files from src to dst, only if they don't exist in dst."""
+    if os.path.isdir(src):
+        if not os.path.isdir(dst):
+            os.makedirs(dst)
+        for item in os.listdir(src):
+            s = os.path.join(src, item)
+            d = os.path.join(dst, item)
+            copy_new_files(s, d)  # Recursive call
+    else:
+        if not os.path.exists(dst):
+            shutil.copy2(src, dst)
+
+def main():
+    # create all contributions
+    for t in contribution_types:
+        if t == 'experimentalist':
+            for s in experimentalist_subtype:
+                bake_contribution(t, s)
+        elif t == 'experiment_runner':
+            for s in runner_subtypes:
+                bake_contribution(t, s)
+        else:
+            bake_contribution(t)
+
+    # get a list of all created folders
+    contribution_folders = [name for name in os.listdir(FOLDER_PATH) if os.path.isdir(os.path.join(FOLDER_PATH, name))]
+
+
+    # make autora
+    os.makedirs(os.path.join(FOLDER_PATH, '.'), exist_ok=True)
+
+    # copy all folders into the autora folder (if they don't exist)
+    for f in contribution_folders:
+        copy_new_files(os.path.join(FOLDER_PATH, f), os.path.join(FOLDER_PATH, '.'))
+        shutil.rmtree(os.path.join(FOLDER_PATH, f))
+
+if __name__ == '__main__':
+    main()

--- a/generate_full/generate.py
+++ b/generate_full/generate.py
@@ -53,7 +53,7 @@ def create_readme():
 
     shutil.copy(readme_src, readme_dist)
 
-    # rempove lines starting with {%
+    # remove lines starting with {%
     output_lines = []
     with open(readme_dist, "r") as file:
         for line in file:


### PR DESCRIPTION
Generating the full README.md

- [x] creating github action
- [x] script creates contribution types and merges them
- [x] README gets copied and {% ... %} gets deleted
- [ ]  TO DO: Clean up README (replace cookiecutter variables)
- [ ]  TO DO: Test everything (checkout created repository)