### PR TITLE
Add current dir option

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -18,6 +18,7 @@
   "advanced_contribution_utilities": ["basic contribution [DEFAULT]", "advanced contribution (dynamic versioning, GitHub actions, pre-commit hooks)"],
   "__contrib_utilities": "{% if cookiecutter.advanced_contribution_utilities == 'basic contribution [DEFAULT]' -%}basic{% else -%}advanced{% endif -%}",
   "license": ["MIT license [DEFAULT]", "BSD license", "ISC license", "Apache Software License 2.0", "GNU General Public License v3", "Not open source"],
+  "use_current_directory": ["no [DEFAULT]", "yes"],
   "__license": "{{ cookiecutter.license.replace( ' [DEFAULT]', '') }}",
   "__contrib_type_modulename": "{{ cookiecutter.__autora_contribution_type.replace(' [DEFAULT]', '').lower().replace(' ', '_').replace('-', '_')  }}",
   "__contrib_subtype_modulename": "{{ cookiecutter.__contrib_subtype.replace(' [DEFAULT]', '').lower().replace(' ', '_').replace('-', '_')  }}",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -4,19 +4,19 @@ import shutil
 
 PROJECT_DIRECTORY = os.path.realpath(os.path.curdir)
 
+
 def move_files_to_parent_folder(folder_path):
     parent_folder = os.path.dirname(folder_path)
+    # Move all files and directories to the parent folder
+    for item in os.listdir(folder_path):
+        source_path = os.path.join(folder_path, item)
+        target_path = os.path.join(parent_folder, item)
+        shutil.move(source_path, target_path)
 
-    for file_name in os.listdir(folder_path):
-        file_path = os.path.join(folder_path, file_name)
-        
-        if os.path.isfile(file_path):
-            shutil.move(file_path, parent_folder)
-        elif os.path.isdir(file_path):
-            move_files_to_parent_folder(file_path)
-
+    # Check if the folder is empty and remove it
     if not os.listdir(folder_path):
         os.rmdir(folder_path)
+
 
 
 if __name__ == '__main__':
@@ -24,7 +24,7 @@ if __name__ == '__main__':
     if 'not_applicable' == '{{ cookiecutter.__contrib_subtype }}':
         shutil.move(
             'src/autora/{{ cookiecutter.__contrib_type_modulename }}/not_applicable/{{ cookiecutter.__contrib_name_modulename }}',
-            'src/autora/{{ cookiecutter.__contrib_type_modulename }}/{{ cookiecutter.__contrib_name_modulename }}',)
+            'src/autora/{{ cookiecutter.__contrib_type_modulename }}/{{ cookiecutter.__contrib_name_modulename }}', )
         os.rmdir('src/autora/{{ cookiecutter.__contrib_type_modulename }}/not_applicable')
     # Remove .pre-commit-config.yaml file if not using pre-commit hooks
     if 'basic' == '{{ cookiecutter.__contrib_utilities }}':
@@ -32,8 +32,5 @@ if __name__ == '__main__':
     # Remove .github directory if not using github actions
     if 'basic' == '{{ cookiecutter.__contrib_utilities }}':
         shutil.rmtree('.github')
-
-
-
-
-
+    if '{{ cookiecutter.use_current_directory }}' == 'yes':
+        move_files_to_parent_folder(PROJECT_DIRECTORY)

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,13 +1,28 @@
 import re
 import sys
+import os
 
 
 MODULE_REGEX = r'^[_a-zA-Z][_a-zA-Z0-9]+$'
 
 module_name = '{{ cookiecutter.__contrib_name_modulename}}'
 
+is_current_directory = '{{ cookiecutter.use_current_directory }}'
+parent_dir = os.path.basename(os.path.realpath(os.path.curdir))
+slug = '{{ cookiecutter.__project_slug }}'
+
+
 if not re.match(MODULE_REGEX, module_name):
     print('ERROR: The project name (%s) is not a valid Python module name.' % module_name)
 
     #Exit to cancel project
     sys.exit(1)
+
+if is_current_directory == 'yes':
+    if parent_dir != slug:
+        print(f'ERROR: When using `use_current_directory`, '
+              f'the parent directory `{parent_dir} '
+              f'must match the contribution name `{slug}`')
+        sys.exit(1)
+
+


### PR DESCRIPTION
Add an option to create the project in the current directory (instead of creating a folder). This avoids unnecessary nesting and makes it more comfortable to first create a folder (for example as a github repo) and then run cookiecutter.