### PR TITLE
add autora as dev depenendncy

### DIFF
--- a/{{ cookiecutter.__project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.__project_slug }}/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "autora-core[dev]"
+    "autora-core[dev]",
+    "autora"
 ]
 
 [project.urls]


### PR DESCRIPTION
In development autora is almost always used (for tests or for examples in basic example). We therefore add it as a dev dependency